### PR TITLE
fix-met.annot: wrong CHEBI id

### DIFF
--- a/ComplementaryData/modelCuration/metabolite_manual_curation.tsv
+++ b/ComplementaryData/modelCuration/metabolite_manual_curation.tsv
@@ -205,7 +205,6 @@ CDP-diacylglycerol (1-16:0, 2-18:1)	CDP-diacylglycerol (1-16:0, 2-18:1)	CHEBI:34
 CDP-diacylglycerol (1-16:1, 2-16:1)	CDP-diacylglycerol (1-16:1, 2-16:1)	CHEBI:104012		0	new chebiID
 CDP-diacylglycerol (1-16:1, 2-18:1)	CDP-diacylglycerol (1-16:1, 2-18:1)			0	Wrong charge in erm/mm.
 CDP-diacylglycerol (1-18:0, 2-16:1)	CDP-diacylglycerol (1-18:0, 2-16:1)			0	No chebi id found. ECMDB23374
-CDP-diacylglycerol (1-18:0, 2-16:1)	CDP-diacylglycerol (1-18:0, 2-16:1)	ECMDB23374		0	Wrong CHEBI in erm/mm.
 CDP-diacylglycerol (1-18:0, 2-18:1)	CDP-diacylglycerol (1-18:0, 2-18:1)			0	Wrong charge in erm.
 CDP-diacylglycerol (1-18:1, 2-16:1)	CDP-diacylglycerol (1-18:1, 2-16:1)			0	Wrong charge in erm/mm.
 CDP-diacylglycerol (1-18:1, 2-18:1)	CDP-diacylglycerol (1-18:1, 2-18:1)	CHEBI:104362		0	new chebiID. CHEBI:104362 for 1.2-dioctadec-11-enoyl-sn-glycero-3-cytidine 5'-diphosphate CDP-DG(18:1/18:1)

--- a/ModelFiles/dependencies.txt
+++ b/ModelFiles/dependencies.txt
@@ -1,7 +1,7 @@
-MATLAB	9.3.0.713579 (R2017b)
+MATLAB	9.4.0.813654 (R2018a)
 libSBML	5.17.0
 RAVEN_toolbox	2.0.0
-COBRA_toolbox	commit 08d1e02
+COBRA_toolbox	commit 4bfe8b3
 SBML_level	3
 SBML_version	1
 fbc_version	2

--- a/ModelFiles/yml/yeastGEM.yml
+++ b/ModelFiles/yml/yeastGEM.yml
@@ -13686,8 +13686,6 @@
     - compartment: erm
     - formula: C46H83N3O15P2
     - charge: 0
-    - annotation: !!omap
-      - chebi: ECMDB23374
   - !!omap
     - id: s_3087
     - name: CDP-diacylglycerol (1-18:1, 2-16:1)
@@ -13794,8 +13792,6 @@
     - compartment: mm
     - formula: C46H83N3O15P2
     - charge: 0
-    - annotation: !!omap
-      - chebi: ECMDB23374
   - !!omap
     - id: s_3101
     - name: phosphatidate (1-18:1, 2-16:1)


### PR DESCRIPTION
A non-compliant CHEBI id passed in last curation and was being stored in metNotes

**I hereby confirm that I have:**

- [X] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---contributor) for running the model
- [X] Selected `devel` as a target branch (top left drop-down menu)
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about this PR
