### PR TITLE
Feat/releaseCheck

### DIFF
--- a/ComplementaryScripts/increaseVersion.m
+++ b/ComplementaryScripts/increaseVersion.m
@@ -14,7 +14,7 @@ end
 
 %Bump version number:
 oldModel   = load('../ModelFiles/mat/yeastGEM.mat');
-oldVersion = oldModel.model.description;
+oldVersion = oldModel.model.modelID;
 oldVersion = oldVersion(strfind(oldVersion,'_v')+2:end);
 oldVersion = str2double(strsplit(oldVersion,'.'));
 newVersion = oldVersion;

--- a/ComplementaryScripts/increaseVersion.m
+++ b/ComplementaryScripts/increaseVersion.m
@@ -49,6 +49,31 @@ model = readCbModel('../ModelFiles/xml/yeastGEM.xml');
 model.modelID = ['yeastGEM_v' newVersion];
 saveYeastModel(model,false)
 
+%Check if any file changed (except for history.md and 1 line in yeastGEM.xml):
+diff   = git('diff --numstat');
+diff   = strsplit(diff,'\n');
+change = false;
+for i = 1:length(diff)
+    diff_i = strsplit(diff{i},'\t');
+    if length(diff_i) == 3
+        %.xml file: 1 line should be added & 1 line should be deleted
+        if strcmp(diff_i{3},'ModelFiles/xml/yeastGEM.xml')
+            if eval([diff_i{1} ' > 1']) || eval([diff_i{2} ' > 1'])
+                disp(['NOTE: File ' diff_i{3} ' is changing more than expected'])
+                change = true;
+            end
+        %Any other file except for history.md: no changes should be detected
+        elseif ~strcmp(diff_i{3},{'history.md'})
+            disp(['NOTE: File ' diff_i{3} ' is changing'])
+            change = true;
+        end
+    end
+end
+if change
+    error(['Some files are changing from devel. To fix, first update devel, ' ...
+        'then merge to master, and try again.'])
+end
+
 %Allow .mat & .xls storage:
 copyfile('../.gitignore','backup')
 fin  = fopen('backup','r');


### PR DESCRIPTION
### Main improvements in this PR:
In our workflow, for each new release there is an extra commit named `chore: new version` in which  version/history/binaries are updated. However, sometimes some other files also change due to e.g. an [update of some dependency](https://github.com/SysBioChalmers/yeast-GEM/commit/2b46934b2a22aff92130e7ce5ee3c361f6c11f2c) by the admin between the moment of the PR in `devel` and the release in `master`. This then leads to conflicts as soon as those files change in `devel` later, producing [extra undesired commits](https://github.com/SysBioChalmers/yeast-GEM/commit/1d3e80dc1f0416c05a6b1231e2ee88b8437d918b) in `master`.

With this PR, `increaseVersion.m` will work if only 2 files change after `saveYeastModel.m` has updated the model: `history.md` and 1 line in `yeastGEM.xml` (the line that specifies the model's version). It does so by parsing the output of `git diff --numstat` (details of the git command [here](https://til.hashrocket.com/posts/992ba0a067-git-diff-numstat)). If more changes are found, the function will error, prompting the admin to first update `devel`, make a new PR, and then do the release.

**I hereby confirm that I have:**

- [X] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---contributor) for running the model
- [X] Selected `devel` as a target branch (top left drop-down menu)
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about this PR