### PR TITLE
fix: RAVEN dependency

### DIFF
--- a/ModelFiles/dependencies.txt
+++ b/ModelFiles/dependencies.txt
@@ -1,6 +1,6 @@
 MATLAB	9.4.0.813654 (R2018a)
 libSBML	5.17.0
-RAVEN_toolbox	2.0.2
+RAVEN_toolbox	commit de33e98
 COBRA_toolbox	commit d7ce7d6
 SBML_level	3
 SBML_version	1


### PR DESCRIPTION
switched RAVEN to `devel` to prevent a bug in exportForGit from the latest release.