### PR TITLE
feat: gene name compliance with cobrapy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ Thumbs.db
 *.asv
 *.m~
 *.mex*
-*.mlappinstall 
+*.mlappinstall
 *.mltbx
 *.mat
 helpsearch*/
@@ -51,3 +51,7 @@ helpsearch*/
 *.xls
 *.xlsx
 *.tab
+
+# Python-related things #
+#########################
+*.ipynb_checkpoints/

--- a/ComplementaryScripts/modelTests/cobrapy-compliance.ipynb
+++ b/ComplementaryScripts/modelTests/cobrapy-compliance.ipynb
@@ -235,7 +235,7 @@
        "            <tr>\n",
        "                <td><strong>Gene identifier</strong></td><td>Q0045</td>\n",
        "            </tr><tr>\n",
-       "                <td><strong>Name</strong></td><td>COBRAProtein1</td>\n",
+       "                <td><strong>Name</strong></td><td>COX1</td>\n",
        "            </tr><tr>\n",
        "                <td><strong>Memory address</strong></td>\n",
        "                <td>0x01b57f39ba48</td>\n",

--- a/ComplementaryScripts/modelTests/cobrapy-compliance.ipynb
+++ b/ComplementaryScripts/modelTests/cobrapy-compliance.ipynb
@@ -1,0 +1,353 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# cobrapy compliance\n",
+    "\n",
+    "Notebook for confirming that every field is preserved when the model is used with cobrapy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using license file C:\\Users\\bejsab\\gurobi.lic\n",
+      "Academic license - for non-commercial use only\n"
+     ]
+    }
+   ],
+   "source": [
+    "import cobra\n",
+    "model = cobra.io.read_sbml_model(\"../../ModelFiles/xml/yeastGEM.xml\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Metabolites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Metabolite identifier</strong></td><td>s_0001[ce]</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Name</strong></td><td>(1->3)-beta-D-glucan [cell envelope]</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x01b5797c4d48</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Formula</strong></td><td>C6H10O5</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartment</strong></td><td>ce</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>In 3 reaction(s)</strong></td><td>\n",
+       "                    r_0005, r_1543, r_4048</td>\n",
+       "            </tr>\n",
+       "        </table>"
+      ],
+      "text/plain": [
+       "<Metabolite s_0001[ce] at 0x1b5797c4d48>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.metabolites[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.metabolites[0].charge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'sbo': ['SBO:0000247'],\n",
+       " 'chebi': 'CHEBI:37671',\n",
+       " 'kegg.compound': 'C00965',\n",
+       " 'metanetx.chemical': 'MNXM6492'}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.metabolites[0].annotation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Reactions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Reaction identifier</strong></td><td>r_2112</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Name</strong></td><td>kynurenine aminotransferase</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x01b57fc40f88</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Stoichiometry</strong></td>\n",
+       "                <td>\n",
+       "                    <p style='text-align:right'>s_1020[c] + s_1399[c] <=> s_0955[c] + s_2763[c]</p>\n",
+       "                    <p style='text-align:right'>L-kynurenine [cytoplasm] + pyruvate [cytoplasm] <=> L-alanine [cytoplasm] + kynurenic acid [cytoplasm]</p>\n",
+       "                </td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>GPR</strong></td><td>YJL060W</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Lower bound</strong></td><td>-1000.0</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Upper bound</strong></td><td>1000.0</td>\n",
+       "            </tr>\n",
+       "        </table>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<Reaction r_2112 at 0x1b57fc40f88>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.reactions.get_by_id(\"r_2112\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'sbo': ['SBO:0000176'],\n",
+       " 'pubmed': '18205391',\n",
+       " 'ec-code': '2.6.1.7',\n",
+       " 'kegg.reaction': 'R01959',\n",
+       " 'metanetx.reaction': 'MNXR99596'}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.reactions.get_by_id(\"r_2112\").annotation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Confidence Level': '3'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.reactions.get_by_id(\"r_2112\").notes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Genes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Gene identifier</strong></td><td>Q0045</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Name</strong></td><td>COBRAProtein1</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x01b57f39ba48</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Functional</strong></td><td>True</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>In 1 reaction(s)</strong></td><td>\n",
+       "                    r_0438</td>\n",
+       "            </tr>\n",
+       "        </table>"
+      ],
+      "text/plain": [
+       "<Gene Q0045 at 0x1b57f39ba48>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.genes[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 4. Subsystems"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'sce00040  Pentose and glucuronate interconversions'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.groups[4].name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{<Reaction r_0164 at 0x1b57f61d488>,\n",
+       " <Reaction r_0168 at 0x1b57f626888>,\n",
+       " <Reaction r_0171 at 0x1b57f62c288>,\n",
+       " <Reaction r_0181 at 0x1b57f648f08>,\n",
+       " <Reaction r_0184 at 0x1b57f6548c8>,\n",
+       " <Reaction r_0205 at 0x1b57f684848>,\n",
+       " <Reaction r_0323 at 0x1b57f77fd08>,\n",
+       " <Reaction r_0365 at 0x1b57f7c7c48>,\n",
+       " <Reaction r_0688 at 0x1b57f9ba308>,\n",
+       " <Reaction r_0691 at 0x1b57f9bf508>,\n",
+       " <Reaction r_0984 at 0x1b57f60a4c8>,\n",
+       " <Reaction r_1084 at 0x1b57fc24548>,\n",
+       " <Reaction r_1092 at 0x1b57fc32748>,\n",
+       " <Reaction r_1093 at 0x1b57fc32f88>,\n",
+       " <Reaction r_1094 at 0x1b57fc37808>}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.groups[4].members"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ComplementaryScripts/saveYeastModel.m
+++ b/ComplementaryScripts/saveYeastModel.m
@@ -36,6 +36,9 @@ cd missingFields
 model = addSBOterms(model);
 cd ..
 
+%Save "proteins" ("fbc:name" in the xml file) = "geneNames" ("fbc:label" in the xml file):
+model.proteins = model.geneNames;
+
 %Check if model is a valid SBML structure:
 writeCbModel(model,'sbml','tempModel.xml');
 [~,errors] = TranslateSBML('tempModel.xml');

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains the current consensus genome-scale metabolic model of _
 
 **GEM Category:** species; **Utilisation:** experimental data reconstruction, multi-omics integrative analysis, _in silico_ strain design, model template; **Field:** metabolic-network reconstruction; **Type of Model:** reconstruction, curated; **Model Source:** YeastMetabolicNetwork; **Omic Source:** genomics, metabolomics; **Taxonomy:** _Saccharomyces cerevisiae_; **Metabolic System:** general metabolism; **Bioreactor**; **Strain:** S288C; **Condition:** aerobic, glucose-limited, defined media;
 
-* Last update: 2020-03-31
+* Last update: 2020-04-21
 
 * Main Model Descriptors:
 


### PR DESCRIPTION
### Main improvements in this PR:
This partly addresses #102: After the merge of https://github.com/opencobra/cobrapy/pull/685, every component in yeast-GEM is properly parsed when loaded into cobrapy, with the exception of gene names (notebook with the 1st analysis [here](https://github.com/SysBioChalmers/yeast-GEM/blob/52c24ab3f795054e671213ee275a6c7ded613cc3/ComplementaryScripts/modelTests/cobrapy-compliance.ipynb)): this is because gene names are stored by cobratoolbox in the `fbc:label` field in the xml file, whereas cobrapy looks for these in the `fbc:name` field. So instead, I've adapted the Matlab saving wrapper so that it copies `model.geneNames` onto `model.proteins`, as that is translated to the compliant `fbc:name` field. By doing this we won't loose any information, as in `model.proteins` we had placeholders until now. The only downside is that the xml will now have duplicated info:

```xml
<fbc:geneProduct metaid="G_YPL078C" fbc:id="G_YPL078C" fbc:name="ATP4" fbc:label="ATP4"/>
```

But as we now over-write the protein info with the wrapper, and cobrapy only reads one of them, we should not have any issues. Also, from now on no need to redefine each time the `model.proteins` field @feiranl.

**I hereby confirm that I have:**

- [x] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---contributor) for running the model
- [x] Selected `devel` as a target branch (top left drop-down menu)
