### PR TITLE
add-rxn.prop: Fatty Acid Ester Addition

### DIFF
--- a/ComplementaryData/modelCuration/Fatty_Acid_Esters_newRxnMatrix.tsv
+++ b/ComplementaryData/modelCuration/Fatty_Acid_Esters_newRxnMatrix.tsv
@@ -1,0 +1,31 @@
+ID	coefficient	standard_name	type	compartment
+MNXR125910	1	hexanoyl-CoA	reactant	cytoplasm
+MNXR125910	1	ethanol	reactant	cytoplasm
+MNXR125910	1	ethyl hexanoate	product	cytoplasm
+MNXR125910	1	coenzyme A	product	cytoplasm
+MNXR125910	1	ethyl hexanoate	reactant	cytoplasm
+MNXR125910	1	ethyl hexanoate	product	extracellular
+MNXR125910	1	octanoyl-CoA	reactant	cytoplasm
+MNXR125910	1	ethanol	reactant	cytoplasm
+MNXR125910	1	ethyl octanoate	product	cytoplasm
+MNXR125910	1	coenzyme A	product	cytoplasm
+MNXR125910	1	ethyl octanoate	reactant	cytoplasm
+MNXR125910	1	ethyl octanoate	product	extracellular
+MNXR125910	1	butyryl-CoA	reactant	cytoplasm
+MNXR125910	1	ethanol	reactant	cytoplasm
+MNXR125910	1	ethyl butanoate	product	cytoplasm
+MNXR125910	1	coenzyme A	product	cytoplasm
+MNXR125910	1	ethyl butanoate	reactant	cytoplasm
+MNXR125910	1	ethyl butanoate	product	extracellular
+MNXR125910	1	acetyl-CoA	reactant	cytoplasm
+MNXR125910	1	1-hexanol	reactant	cytoplasm
+MNXR125910	1	hexyl acetate	product	cytoplasm
+MNXR125910	1	coenzyme A	product	cytoplasm
+MNXR125910	1	hexyl acetate	reactant	cytoplasm
+MNXR125910	1	hexyl acetate	product	extracellular
+MNXR125910	1	 decanoyl-CoA	reactant	cytoplasm
+MNXR125910	1	ethanol	reactant	cytoplasm
+MNXR125910	1	ethyl decanoate	product	cytoplasm
+MNXR125910	1	coenzyme A	product	cytoplasm
+MNXR125910	1	ethyl decanoate	reactant	cytoplasm
+MNXR125910	1	ethyl decanoate	product	extracellular

--- a/ComplementaryData/modelCuration/Fatty_Acid_Esters_newRxnMetAnnotation.tsv
+++ b/ComplementaryData/modelCuration/Fatty_Acid_Esters_newRxnMetAnnotation.tsv
@@ -1,0 +1,16 @@
+NewMetName	Charged formula	Charge	compartment	KEGG ID	CHEBI ID	Remark	Ref
+hexanoyl-CoA[cytoplasm]	C27H46N7O17P3S	-4	cytoplasm	C05270	CHEBI:27540	MNXM553	"exist in model, but in another compartment"
+ethyl hexanoate[cytoplasm]	C8H16O2	0	cytoplasm		CHEBI:86055	MNXM52763	DOI: 10.1074/jbc.M512028201
+ethyl hexanoate[extracellular]	C8H16O2	0	extracellular		CHEBI:86055	MNXM52763	DOI: 10.1074/jbc.M512028201
+octanoyl-CoA[cytoplasm]	C29H46N7O17P3S	-4	cytoplasm	C01944  	ChEBI:15533	MNXM342	"exist in model, but in another compartment"
+ethyl octanoate[cytoplasm]	C10H20O2	0	cytoplasm	C12292	ChEBI:87426	MNXM52785	DOI: 10.1074/jbc.M512028201
+ethyl octanoate[extracellular]	C10H20O2	0	extracellular	C12292	ChEBI:87426	MNXM52785	DOI: 10.1074/jbc.M512028201
+butanoyl-CoA[cytoplasm]	C25H38N7O17P3S	-4	cytoplasm	C00136 	ChEBI:57371	MNXM233	"exist in model, but in another compartment"
+Ethyl butanoate[cytoplasm]	C6H12O2	0	cytoplasm		ChEBI:88764	MNXM11527	DOI: 10.1074/jbc.M512028201
+Ethyl butanoate[extracellular]	C6H12O2	0	extracellular		ChEBI:88764	MNXM11527	DOI: 10.1074/jbc.M512028201
+hexan-1-ol[cytoplasm]	C6H14O	0	cytoplasm		ChEBI:87393	MNXM18358	DOI: 10.1074/jbc.M512028201
+hexyl acetate[cytoplasm]	C8H16O2	0	cytoplasm		ChEBI:87510	MNXM99284	DOI: 10.1074/jbc.M512028201
+hexyl acetate[extracellular]	C8H16O2	0	extracellular		ChEBI:87510	MNXM99284	DOI: 10.1074/jbc.M512028201
+decanoyl-CoA[cytoplasm]	C31H50N7O17P3S	-4	cytoplasm	C05274 	ChEBI:61430	MNXM486	"exist in model, but in another compartment"
+ethyl decanoate[cytoplasm]	C12H24O2	0	cytoplasm		ChEBI:87430	MNXM100679	DOI: 10.1074/jbc.M512028201
+ethyl decanoate[extracellular]	C12H24O2	0	extracellular		ChEBI:87430	MNXM100679	DOI: 10.1074/jbc.M512028201

--- a/ComplementaryData/modelCuration/Fatty_Acid_Esters_newRxnProp.tsv
+++ b/ComplementaryData/modelCuration/Fatty_Acid_Esters_newRxnProp.tsv
@@ -1,0 +1,2 @@
+RxnID	rev	RxnName	EC	rxnID_kegg	Source
+MNXR125910	0	alcohol O-acetyltransferase	2.3.1.84	R00627	rhea:17229

--- a/ComplementaryScripts/modelCuration/addFAEsterRxnToGEM.m
+++ b/ComplementaryScripts/modelCuration/addFAEsterRxnToGEM.m
@@ -1,0 +1,150 @@
+% This Function is for adding fatty acid ester related metabolites/reactions into model.
+% Input: model, Fatty_Acid_Esters_newRxnMatrix.tsv,Fatty_Acid_Esters_newRxnProp.tsv,Fatty_Acid_Esters_newRxnMetAnnotation.tsv.
+%       Extract model info from .tsv format.
+%       Before run the codes below, the file should be manually editted.
+%       COBRA required.
+%       New reaction should be in .tsv format.
+%
+% William T. Scott, Jr. 2019.04.10
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%newreaction:
+% Load model
+cd ..
+model = loadYeastModel;
+%load rxn matrix
+fid = fopen('../ComplementaryData/modelCuration/Fatty_Acid_Esters_newRxnMatrix.tsv');
+newreaction = textscan(fid,'%s %s %s %s %s','Delimiter','\t','HeaderLines',1);
+matrix.rxnIDs    = newreaction{1};
+matrix.metcoef    = cellfun(@str2num, newreaction{2});
+matrix.metIDs = newreaction{3};
+matrix.mettype = newreaction{4};
+matrix.metcompartments = newreaction{5};
+fclose(fid);
+%load rxn prop, which include rxn rev, rxn names, rxn ec numbers, rxn
+%KEGGID and rxn notes.
+fid  = fopen('../ComplementaryData/modelCuration/Fatty_Acid_Esters_newRxnProp.tsv','r');
+rev = textscan(fid,'%s %s %s %s %s %s %s','Delimiter','\t','HeaderLines',1);
+newrxn.ID  = rev{1};
+newrxn.Rev = cellfun(@str2num, rev{2});
+newrxn.rxnNames = rev{3};
+newrxn.rxnECNumbers = rev{4};
+newrxn.rxnKEGGID = rev{5};
+newrxn.rxnNotes  = rev{6};
+newrxn.rxnMetaNetXID = newrxn.ID;
+for i = 1:length(newrxn.rxnMetaNetXID)
+    if ~startsWith(newrxn.rxnMetaNetXID{i},'MNXR')
+        newrxn.rxnMetaNetXID{i} = '';
+    end
+end
+
+fclose(fid);
+
+% Change coefficients for reactants:
+for i=1:length(matrix.rxnIDs)
+    if strcmp(matrix.mettype(i),'reactant')
+        matrix.metcoef(i) = matrix.metcoef(i)*-1;
+    end
+end
+
+% Change compartments:
+CONValldata = cat(2,model.compNames,model.comps);
+lbracket    = ' [' ;
+llbracket   = '[';
+rbrackets   = ']';
+space       = ' ';
+[m, n]      = size(CONValldata);
+for i = 1:m
+    aa = CONValldata(i,1);
+    aa = char(aa);
+    for j=1:length(matrix.rxnIDs)
+        bb = matrix.metcompartments(j,1);
+        bb = char(bb);
+        if strcmp(bb,aa)
+            matrix.Newcomps(j,1) = CONValldata(i,2);
+        end
+    end
+end
+for i=1:length(matrix.rxnIDs)
+    matrix.metnames(i) = strcat(matrix.metIDs(i),lbracket,matrix.metcompartments(i),rbrackets);
+    matrix.Newcomps(i) = strcat(llbracket,matrix.Newcomps(i),rbrackets);
+end
+
+% Map mets to model.metnames, get s_index for new mets:
+cd otherChanges
+for j = 1:length(matrix.metnames)
+    [~,metindex] = ismember(matrix.metnames(j),model.metNames);
+    if metindex ~= 0
+        matrix.mets(j) = model.mets(metindex);
+    elseif metindex == 0
+        newID = getNewIndex(model.mets);
+        matrix.mets(j) = strcat('s_',newID,matrix.Newcomps(j));
+        model = addMetabolite(model,char(matrix.mets(j)), ...
+            'metName',matrix.metnames(j));
+    end
+end
+
+
+% Add metabolite data:
+fid = fopen('../../ComplementaryData/modelCuration/Fatty_Acid_Esters_newRxnMetAnnotation.tsv');
+newmet_annot         = textscan(fid,'%s %s %s %s %s %s %s %s','Delimiter','\t','HeaderLines',1);
+newmet.metNames      = newmet_annot{1};
+newmet.metFormulas   = newmet_annot{2};
+newmet.metCharges    = cellfun(@str2num, newmet_annot{3});
+newmet.metKEGGID     = newmet_annot{5};
+newmet.metChEBIID    = newmet_annot{6};
+newmet.metMetaNetXID = newmet_annot{7};
+
+
+fclose(fid);
+for i = 1:length(newmet.metNames)
+    [~,metID] = ismember(newmet.metNames(i),model.metNames);
+    if metID ~= 0
+        model.metFormulas{metID}   = newmet.metFormulas{i};
+        model.metCharges(metID)    = newmet.metCharges(i);
+        model.metKEGGID{metID}     = newmet.metKEGGID{i};
+        model.metChEBIID{metID}    = newmet.metChEBIID{i};
+        model.metMetaNetXID{metID} = newmet.metMetaNetXID{i};
+        model.metNotes{metID}      = '';
+        model.metNotes{metID} = 'added from metabolomics data';
+    end
+end
+
+% Add new reactions according to rev ID: Met Coef needs to be a column, not
+% a row. Coef should be a double, which was converted at the import section
+EnergyResults     = {};
+MassChargeresults = {};
+RedoxResults      = {};
+if ~isfield(model,'rxnMetaNetXID')
+    model.rxnMetaNetXID = cell(size(model.rxns));
+end
+for i = 1:length(newrxn.ID)
+    newID = getNewIndex(model.rxns);
+    j     = find(strcmp(matrix.rxnIDs,newrxn.ID{i}));
+    Met   = matrix.mets(j);
+    Coef  = transpose(matrix.metcoef(j));
+    [model,rxnIndex] = addReaction(model, ['r_' newID],...
+        'reactionName', newrxn.ID{i},...
+        'metaboliteList',Met,...
+        'stoichCoeffList',Coef,...
+        'reversible',newrxn.Rev(i,1),...
+        'checkDuplicate',1);
+    [EnergyResults,RedoxResults] = CheckEnergyProduction(model,{['r_' newID]},EnergyResults,RedoxResults);
+    [MassChargeresults] = CheckBalanceforSce(model,{['r_' newID]},MassChargeresults);
+    if isempty(rxnIndex)
+        rxnIndex = strcmp(model.rxns,['r_' newID]);
+    end
+    % Add rxn annotation:
+    model.rxnNames{rxnIndex}      = newrxn.rxnNames{i};
+    model.rxnECNumbers(rxnIndex)  = newrxn.rxnECNumbers(i);
+    model.rxnKEGGID(rxnIndex)     = newrxn.rxnKEGGID(i);
+    model.rxnMetaNetXID(rxnIndex) = newrxn.rxnMetaNetXID(i);
+    model.rxnConfidenceScores(rxnIndex) = 0;   %reactions added for metabolomics data
+    model.rxnNotes{rxnIndex} = 'metabolites observed from literature';
+end
+
+
+% Save model:
+cd ..
+saveYeastModel(model)
+cd modelCuration
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This is to update the model to add fatty acid esters, fusel alcohols, and other missing secondary metabolites/reactions (pathways) into yeast-GEM

### Main improvements in this PR:
*Try to be as clear as possible: Is it fixing/adding something in the model? Is it an additional test/function/dataset? PLEASE DELETE THIS LINE.*

**I hereby confirm that I have:**

- [ x] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---contributor) for running the model
- [x ] Selected `devel` as a target branch (top left drop-down menu)
- [ x] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about this PR
