### PR TITLE
chore: change branch names

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,11 +19,11 @@ If you are unsure about the issue, consider asking first in our [Gitter chat roo
 When creating the issue, please make sure:
 
 * You tested your code (if any) with all requirements for running the model.
-* You did your analysis in the `master` branch of the repository.
+* You did your analysis in the `main` branch of the repository.
 * You provide any necessary files/links needed for understanding the issue.
 * You checked that a similar issue does not exist already
 
-Feel free to also comment on any of the [open issues](https://github.com/SysBioChalmers/yeast-GEM/issues). When doing so, please comply with our [code of conduct](https://github.com/SysBioChalmers/yeast-GEM/blob/master/.github/CODE_OF_CONDUCT.md).
+Feel free to also comment on any of the [open issues](https://github.com/SysBioChalmers/yeast-GEM/issues). When doing so, please comply with our [code of conduct](https://github.com/SysBioChalmers/yeast-GEM/blob/main/.github/CODE_OF_CONDUCT.md).
 
 Finally, if you like yeast-GEM please remember to 'star' our Github page (click on the star at top right corner), that way we also have an idea of who is using yeast-GEM!
 
@@ -42,9 +42,9 @@ Here's how to set up yeast-GEM for local development to contribute smaller featu
     git clone https://github.com/<your Github name>/yeast-GEM.git
     ```
 
-4. Check out the branch that you want to contribute to. Most likely that will be ``devel``:
+4. Check out the branch that you want to contribute to. Most likely that will be ``develop``:
     ```
-    git checkout devel
+    git checkout develop
     ```
 
 5. Create a branch for local development based on the previously checked out branch ([see below](#branching-model) for details on the branching model and how to name your branch):
@@ -72,19 +72,19 @@ Here's how to set up yeast-GEM for local development to contribute smaller featu
     ```
     [See below](#semantic-commits) for recommendations on how to name your commits. In case of larger updates, you can of course make several commits on a single contribution. However, if you need to do too many commits, consider if your contribution could be instead split into separate branches (making it easier for reviewing later).
 
-8. Submit a pull request through the GitHub website (https://help.github.com/articles/creating-a-pull-request-from-a-fork/) to the `devel` branch of the original SysBioChalmers repo (not your fork). We recommend ticking the box "Allow edits from maintainers" if you wish for us to be able to contribute directly to your branch (speeding-up the reviewing process).
+8. Submit a pull request through the GitHub website (https://help.github.com/articles/creating-a-pull-request-from-a-fork/) to the `develop` branch of the original SysBioChalmers repo (not your fork). We recommend ticking the box "Allow edits from maintainers" if you wish for us to be able to contribute directly to your branch (speeding-up the reviewing process).
 
 Note that steps 3, 4, 5 and 7 can be done, if you prefer, with any git client, such as [Github Desktop](https://desktop.github.com/).
 
-Finally, and for larger features that you want to work on collaboratively, you may consider to first request to join our development team to get write access to the repository so that you can create a branch directly in the main repository (or simply ask the administrator to create a branch for you). Once you have a new branch, you can push your changes directly to the main repository and when finished, submit a pull request from that branch to ``devel``. [See below](#development-team-guidelines) for more details.
+Finally, and for larger features that you want to work on collaboratively, you may consider to first request to join our development team to get write access to the repository so that you can create a branch directly in the main repository (or simply ask the administrator to create a branch for you). Once you have a new branch, you can push your changes directly to the main repository and when finished, submit a pull request from that branch to ``develop``. [See below](#development-team-guidelines) for more details.
 
 Thank you very much for contributing to yeast-GEM!
 
 #### Branching model
 
-* `devel`: Is the branch all pull-requests should be based on.
+* `develop`: Is the branch all pull-requests should be based on.
 
-* `master`: Is only touched by the administrator and is the branch with the tested & reviewed model that is released or ready for the next release.
+* `main`: Is only touched by the administrator and is the branch with the tested & reviewed model that is released or ready for the next release.
 
 * `gh-pages`: Is only touched by the administrator and for maintaining the [landing page](http://sysbiochalmers.github.io/yeast-GEM/) of yeast-GEM.
 
@@ -126,7 +126,7 @@ Some examples:
 |Update documentation of function|`doc: addDBnewRxn.m`|
 |Update toolbox|`chore: update RAVEN version`|
 
-More examples [here](https://github.com/SysBioChalmers/yeast-GEM/commits/master). A more detailed explanation or comments is encouraged to be left in the commit description.
+More examples [here](https://github.com/SysBioChalmers/yeast-GEM/commits/main). A more detailed explanation or comments is encouraged to be left in the commit description.
 
 ## Development team guidelines
 
@@ -134,7 +134,7 @@ This section is meant for the development team of yeast-GEM. As a member of the 
 
 ### Creating pull requests
 
-Changes to the model _cannot_ be directly committed to the `master` or `devel` branches (in fact they are protected). Commits are made to side-branches, after which pull requests are made for merging with `devel`. For this, follow the [instructions](#contributing-to-the-model) for contributors, but consider that as members of the development team have write access to the repository, you can create a branch directly in the main repository without needing to fork, for your convenience. This means that you can:
+Changes to the model _cannot_ be directly committed to the `main` or `develop` branches (in fact they are protected). Commits are made to side-branches, after which pull requests are made for merging with `develop`. For this, follow the [instructions](#contributing-to-the-model) for contributors, but consider that as members of the development team have write access to the repository, you can create a branch directly in the main repository without needing to fork, for your convenience. This means that you can:
 
 * Skip step 2 of the contribution process.
 * In step 3 of the contribution process, clone directly the original repo:
@@ -150,11 +150,11 @@ Follow all other steps in the same way. Also, when creating your pull request (o
 ### Reviewing pull requests
 
 Every pull request must be approved by at least one reviewer before it can be merged. When reviewing someone else's pull request, keep in mind the following aspects:
-* **Compatibility:** First of all, make sure that the model is still compatible with the loading/saving wrappers (`loadYeastModel.m` & `saveYeastModel.m`) and that no errors appear. Check also that [`dependencies.txt`](https://github.com/SysBioChalmers/yeast-GEM/blob/master/model/dependencies.txt) does not change in any unexpected ways (e.g. an "unknown" toolbox version). Finally, ensure that the SBML fields `model metaid`, `model id` and `model name` never change, as if they change it would create a conflict in the next release.
+* **Compatibility:** First of all, make sure that the model is still compatible with the loading/saving wrappers (`loadYeastModel.m` & `saveYeastModel.m`) and that no errors appear. Check also that [`dependencies.txt`](https://github.com/SysBioChalmers/yeast-GEM/blob/main/model/dependencies.txt) does not change in any unexpected ways (e.g. an "unknown" toolbox version). Finally, ensure that the SBML fields `model metaid`, `model id` and `model name` never change, as if they change it would create a conflict in the next release.
 * **Documentation:** Every change should be justified with a reference/link/argument. This can be provided as data in `/data`, or directly as a comment in the pull request.
-* **Reproducibility:** If there are any added scripts, make sure that if you run them, the model gets updated from how it was in `devel` to how it is in the pull request. For this, you may _locally_ switch to the corresponding branch, replace the `.xml` file with the one from `devel` before the changes, and run the associated scripts. Remember to stash any undesired changes afterwards.
+* **Reproducibility:** If there are any added scripts, make sure that if you run them, the model gets updated from how it was in `develop` to how it is in the pull request. For this, you may _locally_ switch to the corresponding branch, replace the `.xml` file with the one from `develop` before the changes, and run the associated scripts. Remember to stash any undesired changes afterwards.
 * **Style:** Ensure that the changes to the model are compliant with the model's rxn/met/gene naming conventions (when unsure, take a look at a similar field in the model). Also, make sure that scripts have a compliant style, and datasets are straight-forward to understand.
-* When commenting in the review, please comply with our [code of conduct](https://github.com/SysBioChalmers/yeast-GEM/blob/master/.github/CODE_OF_CONDUCT.md).
+* When commenting in the review, please comply with our [code of conduct](https://github.com/SysBioChalmers/yeast-GEM/blob/main/.github/CODE_OF_CONDUCT.md).
 * Avoid vague comments and try to be as explicit as possible (e.g.: _"Please include X here"_ instead of _"X could be included here"_).
 * As much as possible, try to keep the review process in the pull request discussion, and not in separate private emails.
 
@@ -165,16 +165,16 @@ This section is meant for the administrator of this repo. The main duties of the
 * To keep the repository clean and organized, i.e. avoid redundancy in functions and/or data, and keep coherency in naming of files.
 * To manage package dependencies and regularly update them.
 * To help in the reviewing process of external pull requests by assigning reviewers, [labels](https://github.com/SysBioChalmers/yeast-GEM/issues/labels) and [projects](https://github.com/SysBioChalmers/yeast-GEM/projects), if applicable.
-* To keep [issues](https://github.com/SysBioChalmers/yeast-GEM/issues) with the proper labels, and to close them once they are fixed in the `master` branch.
+* To keep [issues](https://github.com/SysBioChalmers/yeast-GEM/issues) with the proper labels, and to close them once they are fixed in the `main` branch.
 * In cases of disagreement between contributors, to decide how to resolve the issue.
-* To merge open pull requests into `devel` regularly (see [below](#merging-contributions)).
+* To merge open pull requests into `develop` regularly (see [below](#merging-contributions)).
 * To generate new releases of the model regularly (see [below](#releasing-a-new-version)).
 
 ### Merging contributions
-The following points should be considered when merging branches to `devel`:
+The following points should be considered when merging branches to `develop`:
 * Make sure the branch gets accepted by at least one developer with writing access.
 * Wait at least a day before merging, to allow other developers to inspect the pull request.
-* As soon as the branch is merged, check if `devel` is still possible to merge to `master` (this can be checked [here](https://github.com/SysBioChalmers/yeast-GEM/compare/devel)). If conflicts appear (which should rarely happen and only if the `.xml` file was changed in an unexpected way by a toolbox update), fix the conflict _locally_ as soon as possible in `devel` and then push it (note, **DO NOT** pull any other changes from `master` to `devel`, just the single file that is creating the conflict).
+* As soon as the branch is merged, check if `develop` is still possible to merge to `main` (this can be checked [here](https://github.com/SysBioChalmers/yeast-GEM/compare/develop)). If conflicts appear (which should rarely happen and only if the `.xml` file was changed in an unexpected way by a toolbox update), fix the conflict _locally_ as soon as possible in `develop` and then push it (note, **DO NOT** pull any other changes from `main` to `develop`, just the single file that is creating the conflict).
 
 ### Managing python dependencies
 
@@ -193,8 +193,8 @@ We use [pip-tools](https://github.com/jazzband/pip-tools) for managing dependenc
 
 ### Releasing a new version
 
-* A merge of `devel` with `master` invokes a new release.
-* A new release should be made as soon as there is substantial new work in `devel` (as rule of thumb, after around 3 pull request merges).
+* A merge of `develop` with `main` invokes a new release.
+* A new release should be made as soon as there is substantial new work in `develop` (as rule of thumb, after around 3 pull request merges).
 
 yeast-GEM follows [semantic versioning](https://semver.org/), adapted to GEMs:
 * A `major` release is seldom used and only meant for a new publication. Backwards compatibility should be, ideally, always preserved.
@@ -211,14 +211,14 @@ yeast-GEM follows [semantic versioning](https://semver.org/), adapted to GEMs:
   * Refactoring of code.
 
 When releasing, please follow these steps:
-  1. Make sure all dependencies in `devel` correspond to the setup from the local computer from which the release will be made. If not, make a single commit in `devel` updating this with a `loadYeastModel`/`saveYeastModel` cycle.
-  2. Create a pull request from `devel` to `master`, indicating all new features/fixes/etc. and referencing every previous pull request included (examples [here](https://github.com/SysBioChalmers/yeast-GEM/releases)). Tip: if any [issue](https://github.com/SysBioChalmers/yeast-GEM/issues) gets solved in the release, write in the pull request description "Closes #X", where "X" is the issue number. That way the issue will be automatically closed after merge.
+  1. Make sure all dependencies in `develop` correspond to the setup from the local computer from which the release will be made. If not, make a single commit in `develop` updating this with a `loadYeastModel`/`saveYeastModel` cycle.
+  2. Create a pull request from `develop` to `main`, indicating all new features/fixes/etc. and referencing every previous pull request included (examples [here](https://github.com/SysBioChalmers/yeast-GEM/releases)). Tip: if any [issue](https://github.com/SysBioChalmers/yeast-GEM/issues) gets solved in the release, write in the pull request description "Closes #X", where "X" is the issue number. That way the issue will be automatically closed after merge.
   3. Merge at least a day after (having at least one accepted review).
-  4. Switch locally to `master`, pull changes and update `history.md`, by putting at the top the same description of the corresponding PR from step 2.
-  5. Bump version with `increaseVersion.m`. **NOTE:** The function will error if unexpected changes are occurring. If this happens, probably step 1 was done incorrectly. To fix it, commit in `devel` any necessary changes and make a new pull request.
+  4. Switch locally to `main`, pull changes and update `history.md`, by putting at the top the same description of the corresponding PR from step 2.
+  5. Bump version with `increaseVersion.m`. **NOTE:** The function will error if unexpected changes are occurring. If this happens, probably step 1 was done incorrectly. To fix it, commit in `develop` any necessary changes and make a new pull request.
   6. Commit changes from steps 4 and 5 with the message `chore: version X.Y.Z`, and push to the remote.
   7. Make the new release at GitHub [here](https://github.com/SysBioChalmers/yeast-GEM/releases/new), using the proper tag "vX.Y.Z" and with the same description as the corresponding PR from step 2.
-  8. Merge locally `master` into `gh-pages` and push to update the landing page.
+  8. Merge locally `main` into `gh-pages` and push to update the landing page.
   9. Review the [Zenodo](https://zenodo.org) release: Every new release from Github (step 7) automatically triggers a new release in Zenodo. However, so far it is not possible to fully customize this release, and some manual curation is needed. This includes:
       * Ensuring the title of the release has the format `SysBioChalmers/yeast-GEM: yeast X.Y.Z`.
       * Correcting author names to include all commit authors and PR reviewers that contributed to the release.
@@ -230,4 +230,4 @@ When releasing, please follow these steps:
 
 ## Acknowledgments
 
-These contribution guidelines were written based on the contribution guidelines of [opencobra/cobrapy](https://github.com/opencobra/cobrapy/blob/devel/.github/CONTRIBUTING.rst) and [SysBioChalmers/RAVEN](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
+These contribution guidelines were written based on the contribution guidelines of [opencobra/cobrapy](https://github.com/opencobra/cobrapy/blob/develop/.github/CONTRIBUTING.rst) and [SysBioChalmers/RAVEN](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -7,7 +7,7 @@
 
 
 #### Current feature/value/output:
-*How the reaction/metabolite/gene/simulation actually looks in the `master` branch. PLEASE DELETE THIS LINE.*
+*How the reaction/metabolite/gene/simulation actually looks in the `main` branch. PLEASE DELETE THIS LINE.*
 
 
 #### Reproducing these results:
@@ -18,6 +18,6 @@
 
 **I hereby confirm that I have:**
 - [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---user) for running the model
-- [ ] Done this analysis in the `master` branch of the repository
+- [ ] Done this analysis in the `main` branch of the repository
 - [ ] Checked that a similar issue does not exist already
 - [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about the issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,5 @@
 **I hereby confirm that I have:**
 
 - [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---contributor) for running the model
-- [ ] Selected `devel` as a target branch (top left drop-down menu)
+- [ ] Selected `develop` as a target branch (top left drop-down menu)
 - [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about this PR

--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -2,9 +2,9 @@ name: YAML validation
 
 on:
   push:
-    branches: [ devel ]
+    branches: [ develop ]
   pull_request:
-    branches: [ master, devel ]
+    branches: [ main, develop ]
 
 jobs:
   yaml-validation:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
- @@ -0,0 +1,94 @@
 # yeast-GEM: The consensus genome-scale metabolic model of _Saccharomyces cerevisiae_
 
 [![DOI](https://zenodo.org/badge/52777598.svg)](https://zenodo.org/badge/latestdoi/52777598) [![GitHub version](https://badge.fury.io/gh/sysbiochalmers%2Fyeast-gem.svg)](https://badge.fury.io/gh/sysbiochalmers%2Fyeast-gem) [![Join the chat at https://gitter.im/SysBioChalmers/yeast-GEM](https://badges.gitter.im/SysBioChalmers/yeast-GEM.svg)](https://gitter.im/SysBioChalmers/yeast-GEM?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)[![Memote history](https://github.com/SysBioChalmers/yeast-GEM/workflows/Memote%20history/badge.svg)](https://sysbiochalmers.github.io/yeast-GEM/history_report.html)

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ This is because `results.db` (the database that stores all memote results) is tr
 * [Gurobi Optimizer](http://www.gurobi.com/registration/download-reg) for any simulations.
 
 ### Installation instructions
-* For users: Clone it from [`master`](https://github.com/SysBioChalmers/yeast-GEM) in the Github repo, or just download [the latest release](https://github.com/SysBioChalmers/yeast-GEM/releases). If you work in python, please create an environment with all requirements:
+* For users: Clone it from [`main`](https://github.com/SysBioChalmers/yeast-GEM) in the Github repo, or just download [the latest release](https://github.com/SysBioChalmers/yeast-GEM/releases). If you work in python, please create an environment with all requirements:
   ```bash
   pip install -r requirements/requirements.txt  # installs all dependencies
   touch .env                                    # creates a .env file for locating the root
   ```
-* For contributors: Fork it to your Github account, and create a new branch from [`devel`](https://github.com/SysBioChalmers/yeast-GEM/tree/devel).
+* For contributors: Fork it to your Github account, and create a new branch from [`develop`](https://github.com/SysBioChalmers/yeast-GEM/tree/develop).
 
 ## Usage
 
@@ -95,7 +95,7 @@ Make sure to load/save the model with the corresponding wrapper functions!
 
 ## Contributing
 
-Contributions are always welcome! Please read the [contributions guideline](https://github.com/SysBioChalmers/yeast-GEM/blob/master/.github/CONTRIBUTING.md) to get started.
+Contributions are always welcome! Please read the [contributions guideline](https://github.com/SysBioChalmers/yeast-GEM/blob/main/.github/CONTRIBUTING.md) to get started.
 
 ## Contributors
 

--- a/code/deprecated/otherChanges/convertYmn2FBC2.m
+++ b/code/deprecated/otherChanges/convertYmn2FBC2.m
@@ -17,7 +17,7 @@
 % So the last SBML2-compatible COBRA version can be downloaded from
 % https://github.com/opencobra/cobratoolbox/tree/10f98a0ab834118c6dfb943970c38d68c7e1ae70
 % 
-% The whole idea of the script is to load curated Yeast 7.6 from 'master'
+% The whole idea of the script is to load curated Yeast 7.6 from 'main'
 % branch, then load SBML3 format model from
 % https://sourceforge.net/projects/yeast/files/, add the missing
 % annotation to the former model, do some final changes and export it to

--- a/code/increaseVersion.m
+++ b/code/increaseVersion.m
@@ -1,7 +1,7 @@
 function increaseVersion(bumpType)
 % increaseVersion
 %   Upgrades the model to a new version. Run this function after merging
-%   changes to the master branch for making a new release.
+%   changes to the main branch for making a new release.
 %
 %   bumpType    One of the following 3 strings: "major", "minor" or
 %               "patch", indicating the type of increase of version to be
@@ -13,10 +13,10 @@ function increaseVersion(bumpType)
 %   Usage: increaseVersion(bumpType)
 %
 
-%Check if in master:
+%Check if in main:
 currentBranch = git('rev-parse --abbrev-ref HEAD');
-if ~strcmp(currentBranch,'master')
-    error('ERROR: not in master')
+if ~strcmp(currentBranch,'main')
+    error('ERROR: not in main')
 end
 
 %Bump version number:
@@ -77,8 +77,8 @@ for i = 1:length(diff)
     end
 end
 if change
-    error(['Some files are changing from devel. To fix, first update devel, ' ...
-        'then merge to master, and try again.'])
+    error(['Some files are changing from develop. To fix, first update develop, ' ...
+        'then merge to main, and try again.'])
 end
 
 %Allow .mat & .xlsx storage:

--- a/code/missingFields/mapIDsViaMNXref.m
+++ b/code/missingFields/mapIDsViaMNXref.m
@@ -35,9 +35,9 @@ end
 % order to load data structure from RAVEN repository since the data is
 % stored in raven toolbox.
 %since right now, MNX reference structure only exist in the RAVEN branch:
-%origin/feat/add_MetaNetX, we need to switch devel branch to that branch, load
+%origin/feat/add_MetaNetX, we need to switch develop branch to that branch, load
 %the file and switch back.
-%remember when this branch is merged to the master branch, change codes
+%remember when this branch is merged to the main branch, change codes
 %below.
 IDfile = 'ravenCobraWrapper.m';
 currentPath = pwd;
@@ -69,8 +69,8 @@ if ~strcmp(currentBranch,'feat/add_MetaNetX')
 end
 cd external/MetaNetX/
 load('MNXref.mat');
-% swich back to the master branch of RAVEN
-git checkout master
+% swich back to the main branch of RAVEN
+git checkout main
 cd(currentPath);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/model/yeast-GEM.yml
+++ b/model/yeast-GEM.yml
@@ -1,7 +1,7 @@
 ---
 !!omap
 - metaData:
-    id: "yeastGEM_devel"
+    id: "yeastGEM_develop"
     name: "The Consensus Genome-Scale Metabolic Model of Yeast"
     date: "2021-06-15"
 - metabolites:


### PR DESCRIPTION
### Main improvements in this PR:
- refactor:
  - rename `master` and `devel` branches to `main` and `develop` (closes #258)

**I hereby confirm that I have:**

- [x] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---contributor) for running the model
- [x] Selected `develop` as a target branch (top left drop-down menu)
- [x] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about this PR
