### PR TITLE
fix: dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/requirements"
+    schedule:
+      interval: "monthly"
+    target-branch: "develop"

--- a/.github/workflows/memote_release.yml
+++ b/.github/workflows/memote_release.yml
@@ -1,7 +1,6 @@
 name: memote release
 
 on:
-  push:
   release:
     type: [published]
 

--- a/.github/workflows/memote_release.yml
+++ b/.github/workflows/memote_release.yml
@@ -1,6 +1,7 @@
 name: memote release
 
 on:
+  push:
   release:
     type: [published]
 

--- a/.github/workflows/memote_release.yml
+++ b/.github/workflows/memote_release.yml
@@ -1,0 +1,44 @@
+name: memote release
+
+on:
+  release:
+    type: [published]
+
+jobs:
+  memote:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout main branch
+      uses: actions/checkout@v2
+      with:
+        ref: main
+    
+    - name: Checkout gh-pages branch
+      uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: gh-pages-repo
+        
+    - name: Set up Python 3
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install memote
+      run: pip install -r requirements/requirements.txt
+        
+    - name: Memote run
+      run: |
+        memote report snapshot --solver-timeout 30 --filename="gh-pages-repo/release_report.html"
+
+    - name: Auto-commit results
+      uses: stefanzweifel/git-auto-commit-action@v4.4.0
+      with:
+        commit_user_name: memote-bot
+        commit_message: "chore: update memote release report"
+        file_pattern: release_report.html
+        branch: gh-pages
+        repository: gh-pages-repo
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - dependabot makes monthly (if required) PR to `develop` instead of `main`
- chore:
  - also store gh-pages memote release workflow configuration in `develop` (was already in `main`: e778a36978c94be4db9085977ce0747dfa166806)

**I hereby confirm that I have:**

- [X] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---contributor) for running the model
- [X] Selected `develop` as a target branch (top left drop-down menu)
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about this PR
