### PR TITLE
fix: use python 3.9.7 in GitHub Actions

### DIFF
--- a/.github/workflows/memote-history.yml
+++ b/.github/workflows/memote-history.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9.7'
 
     - name: Install memote
       run: pip install -r requirements/ci-requirements.txt

--- a/.github/workflows/memote-run.yml
+++ b/.github/workflows/memote-run.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9.7'
 
     - name: Install memote
       run: pip install -r requirements/ci-requirements.txt

--- a/.github/workflows/memote_release.yml
+++ b/.github/workflows/memote_release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9.7'
 
     - name: Install memote
       run: pip install -r requirements/requirements.txt

--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9.7'
 
     - name: Import with cobrapy
       run: |


### PR DESCRIPTION
### Main improvements in this PR:
- fix
  - GitHub Actions [fails](https://github.com/SysBioChalmers/yeast-GEM/runs/3967864108?check_suite_focus=true#step:4:250), and this seems to do with `swiglpk` failing to install on python 3.10.0. Here, python is set to version 3.9.7. Can be returned back to 3.x if the `swiglpk` issue is resolved.
 
**I hereby confirm that I have:**

- [x] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---contributor) for running the model
- [x] Selected `develop` as a target branch (top left drop-down menu)
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about this PR
